### PR TITLE
Revert "bump version number"

### DIFF
--- a/NANDway.py
+++ b/NANDway.py
@@ -438,7 +438,7 @@ def ps3_validate_block(block_data, page_plus_ras_sz, page_sz, blocknr):
 
 if __name__ == "__main__":
 	VERSION_MAJOR = 0
-	VERSION_MINOR = 66
+	VERSION_MINOR = 65
 
 	print "NANDway v%d.%02d - Teensy++ 2.0 NAND Flasher for PS3/Xbox/Wii"%(VERSION_MAJOR, VERSION_MINOR)
 	print "(Original NORway.py by judges <judges@eEcho.com>)"


### PR DESCRIPTION
This reverts commit b548c2cdc086fc7ad92b8c465df81a337ceba400.

The higher version number causes an error with the existing teensy firmware